### PR TITLE
Mount models, uploads to volume so they persist between containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
       API_TOKEN_SALT: ${API_TOKEN_SALT}
       APP_KEYS: ${APP_KEYS}
       NODE_ENV: ${NODE_ENV}
+    volumes:
+      - strapi-models:/opt/app/src
+      - strapi-uploads:/opt/app/public/uploads
     ports:
       - "1337:1337"
     networks:
@@ -59,13 +62,14 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
     volumes:
       - strapi-data:/var/lib/postgresql/data/
-
     ports:
       - "5432:5432"
     networks:
       - strapi
 
 volumes:
+  strapi-models:
+  strapi-uploads:
   strapi-data:
 
 networks:


### PR DESCRIPTION
Strapi stores its models (content-types) [not in the database, but in source](https://docs.strapi.io/dev-docs/faq#why-cant-i-create-or-update-content-types-in-productionstaging). The idea is that the models/schema should live in version control. 

(Strapi also [stores uploads on the filesystem](https://docs.strapi.io/dev-docs/faq#why-are-my-applications-database-and-uploads-resetting-on-paas-type-services), even though those shouldn't live in version control; not sure why.)

In a dockerized strapi setup, this means that on every container restart (or _roughly_ every container restart - when does docker 'recycle' containers?)  any content-types and uploads added via the admin panel will disappear, even though other things like API tokens and users will not. ([A lot of people are quite confused about why.](https://forum.strapi.io/t/data-gets-deleted-when-strapi-container-restarts/17412/53))

Ultimately the models _should_ live in version control, but I think Restore in its current phase is still exploring content-types too rapidly to do that yet; on the other hand, having content-types disappear on every redeploy is untenable for development; so I propose temporarily mounting the src into a volume until some kind of Restore 1.0 is reached. 

For uploads, I think sticking those into a volume is also fine.