### PR TITLE
Treatments and Services routing

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,16 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="src/assets/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="src/assets/favicon-16x16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="src/assets/apple-touch-icon.png">
-    <link rel="manifest" href="src/assets/site.webmanifest">
-    <link rel="mask-icon" href="src/assets/safari-pinned-tab.svg" color="#a888c7">
-    <link rel="shortcut icon" href="src/assets/favicon.ico">
-    <meta name="msapplication-TileColor" content="#00aba9">
-    <meta name="msapplication-config" content="src/assets/browserconfig.xml">
-    <meta name="theme-color" content="#a888c7">
+    <link rel="icon" type="image/png" sizes="32x32" href="/src/assets/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/src/assets/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/src/assets/apple-touch-icon.png" />
+    <link rel="manifest" href="/src/assets/site.webmanifest" />
+    <link rel="mask-icon" href="/src/assets/safari-pinned-tab.svg" color="#a888c7" />
+    <link rel="shortcut icon" href="/src/assets/favicon.ico" />
+    <meta name="msapplication-TileColor" content="#00aba9" />
+    <meta name="msapplication-config" content="/src/assets/browserconfig.xml" />
+    <meta name="theme-color" content="#a888c7" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RESTORE</title>
   </head>

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -18,6 +18,7 @@
         "graphql": "^16.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hash-link": "^1.0.2",
         "react-markdown": "^8.0.7",
         "react-router-dom": "^6.15.0"
       },
@@ -4241,10 +4242,32 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hash-link": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-hash-link/-/react-hash-link-1.0.2.tgz",
+      "integrity": "sha512-fiTlptVRwfWfw17+imVm50S5wlptCfUnm6oIl8GXn5I1bS+wZ4Ejqp/Bx8hhJPK59uNeoce4sJty5pIVaAUAcw==",
+      "dependencies": {
+        "react-loadable": "^5.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-loadable": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
+      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
+      "dependencies": {
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-markdown": {
       "version": "8.0.7",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,7 @@
     "graphql": "^16.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hash-link": "^1.0.2",
     "react-markdown": "^8.0.7",
     "react-router-dom": "^6.15.0"
   },

--- a/packages/client/src/components/Footer.jsx
+++ b/packages/client/src/components/Footer.jsx
@@ -53,7 +53,7 @@ export const Footer = () => {
             ))}
           </Grid>
         </Box>
-        <Box component="img" src="src/assets/bu_logo.webp" height={80} marginLeft={5} marginTop="auto" />
+        <Box component="img" src="/src/assets/bu_logo.webp" height={80} marginLeft={5} marginTop="auto" />
         <Box display="flex" marginLeft="auto" gap={20}>
           <Typography variant="body2" display="flex" flexDirection="column" gap={1}>
             <Link>Link 1</Link>

--- a/packages/client/src/components/InfoPanelA.jsx
+++ b/packages/client/src/components/InfoPanelA.jsx
@@ -2,9 +2,10 @@ import { NavLink } from 'react-router-dom';
 import { Box, Button, Typography } from '@mui/material';
 
 // No idea what to name this. Layout 24 on wireframe.
-export function InfoPanelA({ title, subtitle, imageUrl, imageAlt, iconUrl, iconAlt, buttonText, buttonLink }) {
+export function InfoPanelA({ id, title, subtitle, imageUrl, imageAlt, iconUrl, iconAlt, buttonText, buttonLink }) {
   return (
     <Box
+      id={id}
       sx={{
         display: 'flex',
         flexDirection: { xs: 'column-reverse', md: 'row' },

--- a/packages/client/src/components/SectionedHeader.jsx
+++ b/packages/client/src/components/SectionedHeader.jsx
@@ -1,8 +1,8 @@
 import { Box, Typography } from '@mui/material';
 
-export function SectionedHeader({ title, suptitle, text }) {
+export function SectionedHeader({ id, title, suptitle, text }) {
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'space-between', margin: '0 0 1em 0' }}>
+    <Box id={id} sx={{ display: 'flex', justifyContent: 'space-between', margin: '0 0 1em 0' }}>
       <Box width="50%" sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
         {suptitle && (
           <Typography variant="sectionedHeaderSuptitle" gutterBottom>

--- a/packages/client/src/components/TeamCategory.jsx
+++ b/packages/client/src/components/TeamCategory.jsx
@@ -1,10 +1,11 @@
 import { Box, Grid, Typography } from '@mui/material';
 import { TeamMember } from './TeamMember.jsx';
+import { spacesToDashes } from '../utils.jsx';
 
 export const TeamCategory = ({ TeamCategoryName, Description, team_members }) => {
   return (
     <Box>
-      <Typography variant="h4" component="h2" gutterBottom>
+      <Typography id={spacesToDashes(TeamCategoryName)} variant="h4" component="h2" gutterBottom>
         {TeamCategoryName}
       </Typography>
       {Description && (

--- a/packages/client/src/main.jsx
+++ b/packages/client/src/main.jsx
@@ -14,6 +14,7 @@ import Home from './pages/Home.jsx';
 import Layout from './pages/Layout.jsx';
 import AboutMission from './pages/AboutMission.jsx';
 import TreatmentsServices from './pages/TreatmentsServices.jsx';
+import { ServicesToTheHealthSystem, ServicesToOurPatients } from './pages/TreatmentsServices.jsx';
 import TeamMemberGrid from './pages/Team.jsx';
 import Testimonials from './pages/Testimonials.jsx';
 import ResearchAndEvals from './pages/Research.jsx';
@@ -57,7 +58,21 @@ const router = createBrowserRouter([
       },
       {
         path: 'treatments-and-services',
-        element: <TreatmentsServices />
+        element: <TreatmentsServices />,
+        children: [
+          {
+            index: true,
+            element: <ServicesToTheHealthSystem />
+          },
+          {
+            path: 'services-to-the-health-system',
+            element: <ServicesToTheHealthSystem />
+          },
+          {
+            path: 'services-to-our-patients',
+            element: <ServicesToOurPatients />
+          }
+        ]
       },
       {
         path: 'our-team',

--- a/packages/client/src/pages/AboutMission.jsx
+++ b/packages/client/src/pages/AboutMission.jsx
@@ -4,7 +4,10 @@ import { prependStrapiURL } from '../utils.jsx';
 
 function Strategies() {
   return (
-    <Box sx={{ display: 'flex', flexDirection: { xs: 'column-reverse', md: 'row' }, alignItems: 'center', gap: 2 }}>
+    <Box
+      id="our-strategies"
+      sx={{ display: 'flex', flexDirection: { xs: 'column-reverse', md: 'row' }, alignItems: 'center', gap: 2 }}
+    >
       <Box sx={{ width: { xs: '100%', md: '60%' }, display: 'flex', flexDirection: 'column' }}>
         <Typography variant="infoPanelBTitle" sx={{ textAlign: 'center' }}>
           Our Strategies
@@ -38,6 +41,7 @@ export default function AboutMission() {
   return (
     <>
       <InfoPanelA
+        id="our-mission"
         title="Our Mission"
         subtitle={
           <p>

--- a/packages/client/src/pages/Layout.jsx
+++ b/packages/client/src/pages/Layout.jsx
@@ -5,9 +5,17 @@ import { UniversalHeader } from '../components/Header.jsx';
 import { Footer } from '../components/Footer.jsx';
 import { NavBar } from '../components/NavBar.jsx';
 
+// Hash links do not work well with React bc elements are often not yet
+// available in DOM on load. Slightly better in Firefox than in Chrome,
+// but still suboptimal. Historically people used rafgraph/react-router-hash-link
+// but this is incompatible with React Router v6. React Router considers this
+// issue outside its scope. So:
+import HashLinkObserver from 'react-hash-link';
+
 function Layout() {
   return (
     <>
+      <HashLinkObserver />
       <NavBar />
       <UniversalHeader />
       <Container sx={{ margin: '1rem auto' }}>

--- a/packages/client/src/pages/TreatmentsServices.jsx
+++ b/packages/client/src/pages/TreatmentsServices.jsx
@@ -475,7 +475,9 @@ function UpcomingOngoing() {
 
   return (
     <>
-      <Typography variant="h4">Discover our comprehensive range of psychiatric services at our hospital</Typography>
+      <Typography id="upcoming" variant="h4">
+        Interested in Joining Trainings and Consultations? Find Upcoming Opportunities Below.
+      </Typography>
       <Paper sx={{ margin: '1rem 0', padding: '1rem', border: 'solid', borderRadius: '0.5em' }}>
         <ReactMarkdown>{data.aboutUpcomingOngoing.data.attributes.Body}</ReactMarkdown>
       </Paper>

--- a/packages/client/src/pages/TreatmentsServices.jsx
+++ b/packages/client/src/pages/TreatmentsServices.jsx
@@ -15,6 +15,8 @@ import {
 } from '../gql.jsx';
 import ReactMarkdown from 'react-markdown';
 import { prependStrapiURL } from '../utils.jsx';
+import { theme } from '../theme.jsx';
+import { alpha } from '@mui/material/styles';
 
 import {
   DeterminantsColumn,
@@ -649,6 +651,7 @@ export default function TreatmentsServices() {
             borderColor: 'transparent',
             borderBottom: 'solid',
             borderRightStyle: 'none',
+            '&:hover': { backgroundColor: alpha(theme.palette.purple.light, 0.5) },
             '&.active': { border: 'solid', borderBottomColor: 'transparent' },
             ...(onIndexRoute && { border: 'solid', borderBottomColor: 'transparent' })
           }}
@@ -664,6 +667,7 @@ export default function TreatmentsServices() {
             borderColor: 'transparent',
             borderBottom: 'solid',
             borderRightStyle: 'none',
+            '&:hover': { backgroundColor: alpha(theme.palette.purple.light, 0.5) },
             '&.active': { border: 'solid', borderBottomColor: 'transparent' }
           }}
         >

--- a/packages/client/src/pages/TreatmentsServices.jsx
+++ b/packages/client/src/pages/TreatmentsServices.jsx
@@ -73,7 +73,13 @@ function ImplementationFrameworkInteractive() {
 
   return (
     <>
-      <svg width="900" height="450" viewBox="-10 -10 910 480" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        id="determinants-processes-evaluation"
+        width="900"
+        height="450"
+        viewBox="-10 -10 910 480"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <defs>
           <filter id="shadow">
             <feDropShadow dx="-4" dy="4" stdDeviation="6" floodOpacity="0.5" />
@@ -386,7 +392,7 @@ function OurImplementationModel() {
     );
   }
   return (
-    <Paper sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
+    <Paper id="our-implementation-model" sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
       <Box sx={{ width: '60%', display: 'flex', flexDirection: 'column' }}>
         <Typography variant="infoPanelBTitle">Our Implementation Model</Typography>
         <Typography variant="infoPanelBBody">
@@ -409,7 +415,7 @@ function OurImplementationModel() {
 
 function ImplementationFrameworks() {
   return (
-    <Paper sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
+    <Paper id="implementation-frameworks" sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
       <Box sx={{ width: '40%' }}>
         <img width="100%" src={prependStrapiURL('/uploads/implementationframeworks_8afd8c3f2c.png')} />
       </Box>
@@ -435,7 +441,10 @@ function ImplementationFrameworks() {
 
 function ScopeOfServicesToSystem() {
   return (
-    <Paper sx={{ display: 'flex', flexDirection: 'column', margin: '1rem 0', padding: '2em 10em' }}>
+    <Paper
+      id="scope-of-services"
+      sx={{ display: 'flex', flexDirection: 'column', margin: '1rem 0', padding: '2em 10em' }}
+    >
       <Typography variant="infoPanelBTitle" sx={{ textAlign: 'center' }}>
         Scope of Services to the System
       </Typography>
@@ -493,6 +502,7 @@ function TreatmentsCardGrid() {
   return (
     <>
       <SectionedHeader
+        id="our-treatment-model"
         suptitle="Services to our patients"
         title="Our Treatment Model"
         text="Our treatment model uses a variety of service delivery strategies to maximize the reach and effectiveness of our treatments, and to support patient engagement. Services help patients to get back on the natural recovery path following trauma. All treatments are:"
@@ -504,7 +514,7 @@ function TreatmentsCardGrid() {
 
 function MeasurementBasedCare() {
   return (
-    <Paper sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
+    <Paper id="measurement-based-care" sx={{ display: 'flex', margin: '1rem 0', padding: '2em' }}>
       <Box sx={{ width: '60%', display: 'flex', flexDirection: 'column', padding: '0 2em 0 0' }}>
         <Typography variant="infoPanelBTitle">Measurement-based care</Typography>
         <Typography variant="infoPanelBBody">
@@ -541,7 +551,7 @@ function TreatmentsAndServices() {
   if (error) return <p>Error : {error.message}</p>;
 
   return (
-    <Paper sx={{ margin: '1rem 0', padding: '2em' }}>
+    <Paper id="treatments-and-services" sx={{ margin: '1rem 0', padding: '2em' }}>
       <Typography variant="infoPanelBTitle">Treatments and Services</Typography>
       <Typography variant="infoPanelBBody">
         <ReactMarkdown>{data.treatmentsAndServices.data.attributes.Body}</ReactMarkdown>
@@ -554,6 +564,7 @@ function ScopeOfClinicalFocusPanel() {
   return (
     <>
       <SectionedHeader
+        id="scope-of-clinical-focus"
         title="Scope of Clinical Focus"
         text="We use a combination of the following strategies to support our patients in the continuum of trauma and discrimination related concerns."
       />
@@ -571,7 +582,9 @@ function HowToBecomeARestorePatient() {
 
   return (
     <>
-      <Typography variant="h3">How to Become a RESTORE Patient</Typography>
+      <Typography id="how-to-become-a-restore-patient" variant="h3">
+        How to Become a RESTORE Patient
+      </Typography>
       <Paper sx={{ margin: '1rem 0', padding: '1rem', border: 'solid', borderRadius: '0.5em' }}>
         <ReactMarkdown>{data.howToBecomeARestorePatient.data.attributes.Body}</ReactMarkdown>
       </Paper>
@@ -583,7 +596,7 @@ export function ServicesToTheHealthSystem() {
   return (
     <>
       <OurImplementationModel />
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <Box id="boards" sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Box sx={{ width: '50%' }}>
           <p>RESTORE is overseen by advisory boards that help us center the community in our health equity mission.</p>
           <p>
@@ -608,7 +621,7 @@ export function ServicesToTheHealthSystem() {
 export function ServicesToOurPatients() {
   return (
     <>
-      <Box sx={{ margin: '4rem', width: '576px', display: 'flex', flexDirection: 'column' }}>
+      <Box id="recovery-curve" sx={{ margin: '4rem', width: '576px', display: 'flex', flexDirection: 'column' }}>
         <Typography sx={{ margin: '0 0 1em 0' }}>
           Many people who experience trauma events go on to have natural recovery. Those whose recovery gets interrupted
           go on to develop PTSD.

--- a/packages/client/src/pages/TreatmentsServices.jsx
+++ b/packages/client/src/pages/TreatmentsServices.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Box, Button, Paper, Popper, Typography } from '@mui/material';
 
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
 
 import determinantsVennImg from '../assets/treatments_and_services/determinants_diagram.jpg';
 import ptsdCurveImg from '../assets/treatments_and_services/ptsd-curve.svg';
@@ -575,9 +575,61 @@ function HowToBecomeARestorePatient() {
   );
 }
 
-export default function Services() {
-  const { hash } = useLocation();
-  const [tabValue, setTabValue] = useState(hash || '#Services-to-the-health-system');
+export function ServicesToTheHealthSystem() {
+  return (
+    <>
+      <OurImplementationModel />
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Box sx={{ width: '50%' }}>
+          <p>RESTORE is overseen by advisory boards that help us center the community in our health equity mission.</p>
+          <p>
+            Our boards include: Community Members; Patients; Clinical and Hospital Leadership; Internal Experts;
+            External Experts.
+          </p>
+        </Box>
+        <Box>
+          <img src={prependStrapiURL('/uploads/ourboards_placeholder_1376b51686.png')} />
+        </Box>
+      </Box>
+
+      <ImplementationFrameworks />
+      <ImplementationFrameworkInteractive />
+
+      <ScopeOfServicesToSystem />
+      <UpcomingOngoing />
+    </>
+  );
+}
+
+export function ServicesToOurPatients() {
+  return (
+    <>
+      <Box sx={{ margin: '4rem', width: '576px', display: 'flex', flexDirection: 'column' }}>
+        <Typography sx={{ margin: '0 0 1em 0' }}>
+          Many people who experience trauma events go on to have natural recovery. Those whose recovery gets interrupted
+          go on to develop PTSD.
+        </Typography>
+        <img src={ptsdCurveImg} height="200px" width="576px" />
+      </Box>
+      <TreatmentsCardGrid />
+      <MeasurementBasedCare />
+      <TreatmentsAndServices />
+      <br />
+      <ScopeOfClinicalFocusPanel />
+      <br />
+      <HowToBecomeARestorePatient />
+    </>
+  );
+}
+
+export default function TreatmentsServices() {
+  // The first button/navlink's element (services to system) is also the index element.
+  // When the user is on the root route, they will see the index element, and should ideally
+  // see the first button styled as though it were active; but the relevant NavLink will not
+  // in fact be active.
+  // Therefore, stuck using pathname...
+  const { pathname } = useLocation();
+  const onIndexRoute = pathname === '/treatments-and-services';
 
   return (
     <>
@@ -590,80 +642,36 @@ export default function Services() {
       <Box sx={{ display: 'flex' }}>
         <Button
           component={NavLink}
-          to="#Services-to-the-health-system"
-          onClick={() => setTabValue('#Services-to-the-health-system')}
+          to="services-to-the-health-system"
           sx={{
             padding: '1rem',
             borderRadius: '0',
-            border: 'solid',
-            ...(tabValue === '#Services-to-the-health-system'
-              ? { borderBottomColor: 'transparent' }
-              : { borderColor: 'transparent', borderBottom: 'solid', borderRightStyle: 'none' })
+            borderColor: 'transparent',
+            borderBottom: 'solid',
+            borderRightStyle: 'none',
+            '&.active': { border: 'solid', borderBottomColor: 'transparent' },
+            ...(onIndexRoute && { border: 'solid', borderBottomColor: 'transparent' })
           }}
         >
           <Typography variant="h4">Services to the health system</Typography>
         </Button>
         <Button
           component={NavLink}
-          to="#Services-to-our-patients"
-          onClick={() => setTabValue('#Services-to-our-patients')}
+          to="services-to-our-patients"
           sx={{
             padding: '1rem',
             borderRadius: '0',
-            border: 'solid',
-            ...(tabValue === '#Services-to-our-patients'
-              ? { borderBottomColor: 'transparent' }
-              : { borderColor: 'transparent', borderBottom: 'solid', borderLeftStyle: 'none' })
+            borderColor: 'transparent',
+            borderBottom: 'solid',
+            borderRightStyle: 'none',
+            '&.active': { border: 'solid', borderBottomColor: 'transparent' }
           }}
         >
           <Typography variant="h4">Services to our patients</Typography>
         </Button>
       </Box>
 
-      {tabValue == '#Services-to-the-health-system' && (
-        <>
-          <OurImplementationModel />
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Box sx={{ width: '50%' }}>
-              <p>
-                RESTORE is overseen by advisory boards that help us center the community in our health equity mission.
-              </p>
-              <p>
-                Our boards include: Community Members; Patients; Clinical and Hospital Leadership; Internal Experts;
-                External Experts.
-              </p>
-            </Box>
-            <Box>
-              <img src={prependStrapiURL('/uploads/ourboards_placeholder_1376b51686.png')} />
-            </Box>
-          </Box>
-
-          <ImplementationFrameworks />
-          <ImplementationFrameworkInteractive />
-
-          <ScopeOfServicesToSystem />
-          <UpcomingOngoing />
-        </>
-      )}
-
-      {tabValue == '#Services-to-our-patients' && (
-        <>
-          <Box sx={{ margin: '4rem', width: '576px', display: 'flex', flexDirection: 'column' }}>
-            <Typography sx={{ margin: '0 0 1em 0' }}>
-              Many people who experience trauma events go on to have natural recovery. Those whose recovery gets
-              interrupted go on to develop PTSD.
-            </Typography>
-            <img src={ptsdCurveImg} height="200px" width="576px" />
-          </Box>
-          <TreatmentsCardGrid />
-          <MeasurementBasedCare />
-          <TreatmentsAndServices />
-          <br />
-          <ScopeOfClinicalFocusPanel />
-          <br />
-          <HowToBecomeARestorePatient />
-        </>
-      )}
+      <Outlet />
     </>
   );
 }

--- a/packages/client/src/utils.jsx
+++ b/packages/client/src/utils.jsx
@@ -20,3 +20,8 @@ export function processMarkdownImageUri(url) {
 export function generateBlogPostPath(id, title) {
   return `/blog/${id}/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 }
+
+// This function replaces spaces with dashes.
+export function spacesToDashes(text) {
+  return text.replace(/ /g, '-');
+}


### PR DESCRIPTION
### Some notes on the hash link stuff

(Before this PR: )
Hash links do not work well with React bc elements are often not yet available in DOM on load. 
The behavior was slightly better in Firefox than in Chrome, but still suboptimal. (In Firefox it would only jump to the element whose id is in the hash if the page was already loaded and you hit enter on the browser url bar a second time; in Chrome, doing that would just refresh the page, and it never jumped to the relevant element. Plus other small subtle differences.)
Historically people used rafgraph/react-router-hash-link to solve this problem, but that is incompatible with React Router v6.

(This PR: )
Adds & uses React Hash Link https://www.npmjs.com/package/react-hash-link

(Notes: )

This didn't work: https://dev.to/mindactuate/scroll-to-anchor-element-with-react-router-v6-38op
This didn't work: https://ncoughlin.com/posts/react-router-v6-hash-links/

React _Router_ Hash Link is the historical solution but doesn't work with React Router v6: https://www.npmjs.com/package/react-router-hash-link
...but one day it might?: https://github.com/rafgraph/react-router-hash-link/issues/92#issuecomment-1028149600

React Router considers this functionality outside its domain: https://github.com/remix-run/react-router/issues/7780#issuecomment-789135713

